### PR TITLE
Add logs to make sure flutter local notification calls setExactAndAll…

### DIFF
--- a/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
+++ b/flutter_local_notifications/android/src/main/java/com/dexterous/flutterlocalnotifications/FlutterLocalNotificationsPlugin.java
@@ -511,12 +511,14 @@ public class FlutterLocalNotificationsPlugin
 
     AlarmManager alarmManager = getAlarmManager(context);
     if (BooleanUtils.getValue(notificationDetails.allowWhileIdle)) {
+      System.out.println("I/Blink22-flutterlocalnotifications: Scheduling a notification with exact and allowWhileIdle");
       AlarmManagerCompat.setExactAndAllowWhileIdle(
           alarmManager,
           AlarmManager.RTC_WAKEUP,
           notificationDetails.millisecondsSinceEpoch,
           pendingIntent);
     } else {
+      System.out.println("I/Blink22-flutterlocalnotifications: Scheduling a notification with exact");
       AlarmManagerCompat.setExact(
           alarmManager,
           AlarmManager.RTC_WAKEUP,


### PR DESCRIPTION
…owWhileIdle on android manager.

As this repository hosts two packages, please ensure the PR title starts with the name of the package that it relates to using square brackets (e.g. [flutter_local_notifications]). The contribution guidelines can be found at https://github.com/MaikuB/flutter_local_notifications/blob/master/CONTRIBUTING.md. Please review this as it contains details on what to follow when submitting a PR.
